### PR TITLE
Fix v2 of Consumer Recipes and update SLF4J

### DIFF
--- a/byte-to-eat-v1-docker-consumer-orders/Dockerfile
+++ b/byte-to-eat-v1-docker-consumer-orders/Dockerfile
@@ -1,4 +1,4 @@
 FROM openjdk:21-jdk-slim
 RUN mkdir /app
-COPY target/java-datacontracts-consumer-orders-1.1.0.jar /app/java-datacontracts-consumer-orders-1.1.0.jar
-CMD ["java","-jar","/app/java-datacontracts-consumer-orders-1.1.0.jar","/app/consumer-orders.properties"]
+COPY target/java-datacontracts-consumer-orders-2.0.0.jar /app/java-datacontracts-consumer-orders-2.0.0.jar
+CMD ["java","-jar","/app/java-datacontracts-consumer-orders-2.0.0.jar","/app/consumer-orders.properties"]

--- a/byte-to-eat-v1-docker-consumer-orders/docker-compose.yml
+++ b/byte-to-eat-v1-docker-consumer-orders/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   consumer:
-    image: wvella/byte-to-eat-docker-consumer-orders:1.1.0
+    image: wvella/byte-to-eat-docker-consumer-orders:2.0.0
     container_name: consumer-orders
     volumes:
       - ./consumer-orders.properties:/app/consumer-orders.properties

--- a/byte-to-eat-v1-docker-consumer-orders/pom.xml
+++ b/byte-to-eat-v1-docker-consumer-orders/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>java-datacontracts-consumer-orders</artifactId>
     <packaging>jar</packaging>
-    <version>1.1.0</version>
+    <version>2.0.0</version>
 
     <organization>
         <name>Confluent, Inc.</name>
@@ -25,7 +25,7 @@
 
     <properties>
         <java.version>8</java.version>
-        <slf4j-api.version>1.7.6</slf4j-api.version>
+        <slf4j-api.version>2.0.17</slf4j-api.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <io.confluent.schema-registry.version>${confluent.version.range}</io.confluent.schema-registry.version>
     </properties>

--- a/byte-to-eat-v1-docker-consumer-recipes/Dockerfile
+++ b/byte-to-eat-v1-docker-consumer-recipes/Dockerfile
@@ -1,4 +1,4 @@
 FROM openjdk:21-jdk-slim
 RUN mkdir /app
-COPY target/java-datacontracts-consumer-recipes-1.2.0.jar /app/java-datacontracts-consumer-recipes-1.2.0.jar
-CMD ["java","-jar","/app/java-datacontracts-consumer-recipes-1.2.0.jar","/app/consumer-recipes.properties"]
+COPY target/java-datacontracts-consumer-recipes-2.0.0.jar /app/java-datacontracts-consumer-recipes-2.0.0.jar
+CMD ["java","-jar","/app/java-datacontracts-consumer-recipes-2.0.0.jar","/app/consumer-recipes.properties"]

--- a/byte-to-eat-v1-docker-consumer-recipes/docker-compose.yml
+++ b/byte-to-eat-v1-docker-consumer-recipes/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   consumer:
-    image: wvella/byte-to-eat-docker-consumer-recipes:1.2.0
+    image: wvella/byte-to-eat-docker-consumer-recipes:2.0.0
     container_name: consumer-recipes
     volumes:
       - ./consumer-recipes.properties:/app/consumer-recipes.properties

--- a/byte-to-eat-v1-docker-consumer-recipes/pom.xml
+++ b/byte-to-eat-v1-docker-consumer-recipes/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>java-datacontracts-consumer-recipes</artifactId>
     <packaging>jar</packaging>
-    <version>1.2.0</version>
+    <version>2.0.0</version>
 
     <organization>
         <name>Confluent, Inc.</name>
@@ -25,7 +25,7 @@
 
     <properties>
         <java.version>8</java.version>
-        <slf4j-api.version>1.7.6</slf4j-api.version>
+        <slf4j-api.version>2.0.17</slf4j-api.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <io.confluent.schema-registry.version>${confluent.version.range}</io.confluent.schema-registry.version>
     </properties>

--- a/byte-to-eat-v1-docker-producer-orders/Dockerfile
+++ b/byte-to-eat-v1-docker-producer-orders/Dockerfile
@@ -1,4 +1,4 @@
 FROM openjdk:21-jdk-slim
 RUN mkdir /app
-COPY target/java-datacontracts-producer-orders-1.1.0.jar /app/java-datacontracts-producer-orders-1.1.0.jar
-CMD ["java","-jar","/app/java-datacontracts-producer-orders-1.1.0.jar","/app/producer-orders.properties"]
+COPY target/java-datacontracts-producer-orders-2.0.0.jar /app/java-datacontracts-producer-orders-2.0.0.jar
+CMD ["java","-jar","/app/java-datacontracts-producer-orders-2.0.0.jar","/app/producer-orders.properties"]

--- a/byte-to-eat-v1-docker-producer-orders/docker-compose.yml
+++ b/byte-to-eat-v1-docker-producer-orders/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   producer:
-    image: wvella/byte-to-eat-docker-producer-orders:1.1.0
+    image: wvella/byte-to-eat-docker-producer-orders:2.0.0
     container_name: producer-orders
     volumes:
       - ./producer-orders.properties:/app/producer-orders.properties

--- a/byte-to-eat-v1-docker-producer-orders/pom.xml
+++ b/byte-to-eat-v1-docker-producer-orders/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>java-datacontracts-producer-orders</artifactId>
     <packaging>jar</packaging>
-    <version>1.1.0</version>
+    <version>2.0.0</version>
 
     <organization>
         <name>Confluent, Inc.</name>
@@ -25,7 +25,7 @@
 
     <properties>
         <java.version>8</java.version>
-        <slf4j-api.version>1.7.6</slf4j-api.version>
+        <slf4j-api.version>2.0.17</slf4j-api.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <io.confluent.schema-registry.version>${confluent.version.range}</io.confluent.schema-registry.version>
     </properties>

--- a/byte-to-eat-v1-docker-producer-recipes/Dockerfile
+++ b/byte-to-eat-v1-docker-producer-recipes/Dockerfile
@@ -1,4 +1,4 @@
 FROM openjdk:21-jdk-slim
 RUN mkdir /app
-COPY target/java-datacontracts-producer-recipes-1.2.0.jar /app/java-datacontracts-producer-recipes-1.2.0.jar
-CMD ["java","-jar","/app/java-datacontracts-producer-recipes-1.2.0.jar","/app/producer-recipes.properties"]
+COPY target/java-datacontracts-producer-recipes-2.0.0.jar /app/java-datacontracts-producer-recipes-2.0.0.jar
+CMD ["java","-jar","/app/java-datacontracts-producer-recipes-2.0.0.jar","/app/producer-recipes.properties"]

--- a/byte-to-eat-v1-docker-producer-recipes/docker-compose.yml
+++ b/byte-to-eat-v1-docker-producer-recipes/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   producer:
-    image: wvella/byte-to-eat-docker-producer-recipes:1.2.0
+    image: wvella/byte-to-eat-docker-producer-recipes:2.0.0
     container_name: producer-recipes
     volumes:
       - ./producer-recipes.properties:/app/producer-recipes.properties

--- a/byte-to-eat-v1-docker-producer-recipes/pom.xml
+++ b/byte-to-eat-v1-docker-producer-recipes/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>java-datacontracts-producer-recipes</artifactId>
     <packaging>jar</packaging>
-    <version>1.2.0</version>
+    <version>2.0.0</version>
 
     <organization>
         <name>Confluent, Inc.</name>
@@ -25,7 +25,7 @@
 
     <properties>
         <java.version>8</java.version>
-        <slf4j-api.version>1.7.6</slf4j-api.version>
+        <slf4j-api.version>2.0.17</slf4j-api.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <io.confluent.schema-registry.version>${confluent.version.range}</io.confluent.schema-registry.version>
     </properties>

--- a/byte-to-eat-v2-docker-consumer-recipes/Dockerfile
+++ b/byte-to-eat-v2-docker-consumer-recipes/Dockerfile
@@ -1,4 +1,4 @@
 FROM openjdk:21-jdk-slim
 RUN mkdir /app
-COPY target/java-datacontracts-consumer-recipes-2.2.0.jar /app/java-datacontracts-consumer-recipes-2.2.0.jar
-CMD ["java","-jar","/app/java-datacontracts-consumer-recipes-2.2.0.jar","/app/consumer-recipes.properties"]
+COPY target/java-datacontracts-consumer-recipes-3.0.0.jar /app/java-datacontracts-consumer-recipes-3.0.0.jar
+CMD ["java","-jar","/app/java-datacontracts-consumer-recipes-3.0.0.jar","/app/consumer-recipes.properties"]

--- a/byte-to-eat-v2-docker-consumer-recipes/docker-compose.yml
+++ b/byte-to-eat-v2-docker-consumer-recipes/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   consumer:
-    image: wvella/byte-to-eat-docker-consumer-recipes:2.2.0
+    image: wvella/byte-to-eat-docker-consumer-recipes:3.0.0
     container_name: consumer-recipes-v2
     volumes:
       - ./consumer-recipes.properties:/app/consumer-recipes.properties

--- a/byte-to-eat-v2-docker-consumer-recipes/pom.xml
+++ b/byte-to-eat-v2-docker-consumer-recipes/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>java-datacontracts-consumer-recipes</artifactId>
     <packaging>jar</packaging>
-    <version>2.2.0</version>
+    <version>3.0.0</version>
 
     <organization>
         <name>Confluent, Inc.</name>
@@ -25,7 +25,7 @@
 
     <properties>
         <java.version>8</java.version>
-        <slf4j-api.version>1.7.6</slf4j-api.version>
+        <slf4j-api.version>2.0.17</slf4j-api.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <io.confluent.schema-registry.version>${confluent.version.range}</io.confluent.schema-registry.version>
     </properties>

--- a/byte-to-eat-v2-docker-consumer-recipes/src/main/java/io/confluent/wvella/demo/datacontractsv2/ConsumerAvroRecipes.java
+++ b/byte-to-eat-v2-docker-consumer-recipes/src/main/java/io/confluent/wvella/demo/datacontractsv2/ConsumerAvroRecipes.java
@@ -16,7 +16,7 @@
 
 package io.confluent.wvella.demo.datacontractsv2;
 
-import static io.confluent.wvella.demo.datacontractsv1.Util.loadConfig;
+import static io.confluent.wvella.demo.datacontractsv2.Util.loadConfig;
 
 import java.time.Duration;
 import java.util.Arrays;

--- a/byte-to-eat-v2-docker-consumer-recipes/src/main/java/io/confluent/wvella/demo/datacontractsv2/Util.java
+++ b/byte-to-eat-v2-docker-consumer-recipes/src/main/java/io/confluent/wvella/demo/datacontractsv2/Util.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.confluent.wvella.demo.datacontractsv1;
+package io.confluent.wvella.demo.datacontractsv2;
 
 import java.io.FileInputStream;
 import java.io.IOException;

--- a/byte-to-eat-v2-docker-producer-recipes/Dockerfile
+++ b/byte-to-eat-v2-docker-producer-recipes/Dockerfile
@@ -1,4 +1,4 @@
 FROM openjdk:21-jdk-slim
 RUN mkdir /app
-COPY target/java-datacontracts-producer-recipes-2.2.0.jar /app/java-datacontracts-producer-recipes-2.2.0.jar
-CMD ["java","-jar","/app/java-datacontracts-producer-recipes-2.2.0.jar","/app/producer-recipes.properties"]
+COPY target/java-datacontracts-producer-recipes-3.0.0.jar /app/java-datacontracts-producer-recipes-3.0.0.jar
+CMD ["java","-jar","/app/java-datacontracts-producer-recipes-3.0.0.jar","/app/producer-recipes.properties"]

--- a/byte-to-eat-v2-docker-producer-recipes/docker-compose.yml
+++ b/byte-to-eat-v2-docker-producer-recipes/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   producer:
-    image: wvella/byte-to-eat-docker-producer-recipes:2.1.0
+    image: wvella/byte-to-eat-docker-producer-recipes:3.0.0
     container_name: producer-recipes-v2
     volumes:
       - ./producer-recipes.properties:/app/producer-recipes.properties

--- a/byte-to-eat-v2-docker-producer-recipes/pom.xml
+++ b/byte-to-eat-v2-docker-producer-recipes/pom.xml
@@ -12,7 +12,7 @@
 
     <artifactId>java-datacontracts-producer-recipes</artifactId>
     <packaging>jar</packaging>
-    <version>2.2.0</version>
+    <version>3.0.0</version>
 
     <organization>
         <name>Confluent, Inc.</name>
@@ -25,7 +25,7 @@
 
     <properties>
         <java.version>8</java.version>
-        <slf4j-api.version>1.7.6</slf4j-api.version>
+        <slf4j-api.version>2.0.17</slf4j-api.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <io.confluent.schema-registry.version>${confluent.version.range}</io.confluent.schema-registry.version>
     </properties>

--- a/terraform/confluent-cloud/main/0-build.sh
+++ b/terraform/confluent-cloud/main/0-build.sh
@@ -1,23 +1,23 @@
 # Producer Recipes v1
-make build SERVICE=byte-to-eat-v1-docker-producer-recipes IMAGE_NAME=byte-to-eat-docker-producer-recipes IMAGE_TAG=1.2.0
-make docker-push SERVICE=byte-to-eat-v1-docker-producer-recipes IMAGE_NAME=byte-to-eat-docker-producer-recipes IMAGE_TAG=1.2.0
+make build SERVICE=byte-to-eat-v1-docker-producer-recipes IMAGE_NAME=byte-to-eat-docker-producer-recipes IMAGE_TAG=2.0.0
+make docker-push SERVICE=byte-to-eat-v1-docker-producer-recipes IMAGE_NAME=byte-to-eat-docker-producer-recipes IMAGE_TAG=2.0.0
 
 # Consumer Recipes v1
-make build SERVICE=byte-to-eat-v1-docker-consumer-recipes IMAGE_NAME=byte-to-eat-docker-consumer-recipes IMAGE_TAG=1.2.0
-make docker-push SERVICE=byte-to-eat-v1-docker-consumer-recipes IMAGE_NAME=byte-to-eat-docker-consumer-recipes IMAGE_TAG=1.2.0
+make build SERVICE=byte-to-eat-v1-docker-consumer-recipes IMAGE_NAME=byte-to-eat-docker-consumer-recipes IMAGE_TAG=2.0.0
+make docker-push SERVICE=byte-to-eat-v1-docker-consumer-recipes IMAGE_NAME=byte-to-eat-docker-consumer-recipes IMAGE_TAG=2.0.0
 
 # Producer Recipes v2
-make build SERVICE=byte-to-eat-v2-docker-producer-recipes IMAGE_NAME=byte-to-eat-docker-producer-recipes IMAGE_TAG=2.2.0
-make docker-push SERVICE=byte-to-eat-v2-docker-producer-recipes IMAGE_NAME=byte-to-eat-docker-producer-recipes IMAGE_TAG=2.2.0
+make build SERVICE=byte-to-eat-v2-docker-producer-recipes IMAGE_NAME=byte-to-eat-docker-producer-recipes IMAGE_TAG=3.0.0
+make docker-push SERVICE=byte-to-eat-v2-docker-producer-recipes IMAGE_NAME=byte-to-eat-docker-producer-recipes IMAGE_TAG=3.0.0
 
 # Consumer Recipes v2
-make build SERVICE=byte-to-eat-v2-docker-consumer-recipes IMAGE_NAME=byte-to-eat-docker-consumer-recipes IMAGE_TAG=2.2.0
-make docker-push SERVICE=byte-to-eat-v2-docker-consumer-recipes IMAGE_NAME=byte-to-eat-docker-consumer-recipes IMAGE_TAG=2.2.0
+make build SERVICE=byte-to-eat-v2-docker-consumer-recipes IMAGE_NAME=byte-to-eat-docker-consumer-recipes IMAGE_TAG=3.0.0
+make docker-push SERVICE=byte-to-eat-v2-docker-consumer-recipes IMAGE_NAME=byte-to-eat-docker-consumer-recipes IMAGE_TAG=3.0.0
 
 # Producer Orders
-make build SERVICE=byte-to-eat-v1-docker-producer-orders IMAGE_NAME=byte-to-eat-docker-producer-orders IMAGE_TAG=1.1.0
-make docker-push SERVICE=byte-to-eat-v1-docker-producer-orders IMAGE_NAME=byte-to-eat-docker-producer-orders IMAGE_TAG=1.1.0
+make build SERVICE=byte-to-eat-v1-docker-producer-orders IMAGE_NAME=byte-to-eat-docker-producer-orders IMAGE_TAG=2.0.0
+make docker-push SERVICE=byte-to-eat-v1-docker-producer-orders IMAGE_NAME=byte-to-eat-docker-producer-orders IMAGE_TAG=2.0.0
 
 # Consumer Orders
-make build SERVICE=byte-to-eat-v1-docker-consumer-orders IMAGE_NAME=byte-to-eat-docker-consumer-orders IMAGE_TAG=1.1.0
-make docker-push SERVICE=byte-to-eat-v1-docker-consumer-orders IMAGE_NAME=byte-to-eat-docker-consumer-orders IMAGE_TAG=1.1.0
+make build SERVICE=byte-to-eat-v1-docker-consumer-orders IMAGE_NAME=byte-to-eat-docker-consumer-orders IMAGE_TAG=2.0.0
+make docker-push SERVICE=byte-to-eat-v1-docker-consumer-orders IMAGE_NAME=byte-to-eat-docker-consumer-orders IMAGE_TAG=2.0.0

--- a/terraform/confluent-cloud/main/helper-scripts/migration_rules.json
+++ b/terraform/confluent-cloud/main/helper-scripts/migration_rules.json
@@ -65,7 +65,7 @@
           "Sensitive"
         ],
         "params": {
-          "encrypt.kek.name": "bytetoeat-68q7w1-kek"
+          "encrypt.kek.name": "<< automatically filled out by register-migration-rules.sh >>"
         },
         "onFailure": "ERROR,NONE",
         "disabled": false


### PR DESCRIPTION
This pull request updates multiple services across the project to use newer versions of their respective artefacts and dependencies. The changes include version upgrades for JAR files, Docker images, and SLF4J dependencies, along with minor refactoring in the `byte-to-eat-v2-docker-consumer-recipes` module to align with the updated package structure.

### Version Upgrades
* Updated JAR file versions in `Dockerfile`, `docker-compose.yml` and `pom.xml` for:
  - `byte-to-eat-v1-docker-consumer-orders` (1.1.0 → 2.0.0)
  - `byte-to-eat-v1-docker-consumer-recipes` (1.2.0 → 2.0.0)
  - `byte-to-eat-v1-docker-producer-orders` (1.1.0 → 2.0.0)
  - `byte-to-eat-v1-docker-producer-recipes` (1.2.0 → 2.0.0)
  - `byte-to-eat-v2-docker-consumer-recipes` (2.2.0 → 3.0.0)
  - `byte-to-eat-v2-docker-producer-recipes` (2.2.0 → 3.0.0)

### Dependency Updates
* Upgraded `slf4j-api.version` in `pom.xml` files from 1.7.6 to 2.0.17 across all modules. [[1]](diffhunk://#diff-40e6aaf0a9f0d1ed3678a98edf6762f82ec4d53dd0aa3db38b82e8922484569eL28-R28) [[2]](diffhunk://#diff-2125917986d98b24bf749e02a7d343ab68cb2f9c7e26436ded9a50ce69d812bfL28-R28) [[3]](diffhunk://#diff-c7d701e5ad63508b23d33af0be11863ca0581584646ea1ab192b8d8ffb299400L28-R28) [[4]](diffhunk://#diff-5c2f0023d9c9453ae11f03dbc7c8a2b33fc1f26cf7dea74810c08e7a667a9d0cL28-R28) [[5]](diffhunk://#diff-e551f6ec2f294383a9a00ecfe91b30686e3ebab2d59b9d4dd5fa35949226017eL28-R28) [[6]](diffhunk://#diff-a584915d3ae4ce087e3fc4f79f55e3e28965efdc4156871f4d2c0b3b018f1b23L28-R28)

### Code Refactoring
* Updated package references in `byte-to-eat-v2-docker-consumer-recipes`:
  - Changed `import` statements in `ConsumerAvroRecipes.java` to use `datacontractsv2` package.
  - Updated package declaration in `Util.java` to `datacontractsv2`.